### PR TITLE
Operator updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 secrets/*
 .idea/*
+
+license

--- a/kong-gateway-operator.md
+++ b/kong-gateway-operator.md
@@ -9,7 +9,7 @@ We will Deploy the Kong Gateway using the Kong Operator and deploy the Control P
 - [Register a cluster to Red Hat Market place](#register-a-cluster-to-red-hat-market-place)
 - [Deploy Sample App](#deploy-sample-app)
 - [Install the Operator](#install-operator-subscription)
-- [Patch the Operator Deployment](#install-operator-subscription)
+- [Patch the Operator Deployment](#patch-operator-deployment)
 - [Create Control Plane Namespace](#create-control-plane-namespace)
 - [Create Control Plane Secrets](#create-control-plane-secrets)
 - [Deploy kong operator for Control Plane](#deploy-kong-operator-for-control-plane)


### PR DESCRIPTION
- Patch the kong-operator deployment defining env vars `RELATED_IMAGE_KONG` and `RELATED_IMAGE_KONG_CONTROLLER`
- Use `unifiedRepoTags` when deploying Kong operator instances on `ingressController.image` and `image`.