### PR TITLE
Federation wip

### DIFF
--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -584,6 +584,12 @@ oc delete pvc,po --force --grace-period=0 --all -n kong-mesh-metrics
 kumactl install control-plane --cni-enabled --license-path=./license | oc delete -f -
 sleep 3;
 oc delete po,pvc --all -n kong-mesh-system --force --grace-period=0
+sleep 3;
+oc delete clusterrolebinding cluster-monitoring-view   
+oc delete clusterrolebinding kong-prom-binding
+oc delete clusterrole kong-prom 
+
+oc delete ns grafana
 ```
 
 # Gotchas

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -16,6 +16,7 @@ We will federate the Kong Mesh Prometheus to the OpenShift Prometheus. We will t
 - [Verify you are scraping Metrics](#verify-you-are-scraping-metrics)
 - [Create Prom Rules](#create-prometheusrules)
 - [Create Grafana Dashboards](#create-grafana-dashboards)
+- [Gotchas](#gotchas)
 - [Clean Up](#clean-up)
 - [IGNORE- Test The Federate Endpoint of Kong Prometheus](#test-the-federate-endpoint-of-kong-prometheus)
 ---
@@ -590,23 +591,8 @@ oc delete po,pvc --all -n kong-mesh-system --force --grace-period=0
 - in Grafana Dashboards, Prometheus DataSource `uid` must be `Prometheus` with Capital "P". 
 
 
-## Test The Federate Endpoint of Kong Prometheus
-**Ignore** Do not do this block, we are currently getting way too many metrics and need to filter down. This is effectively a DDoS attack on the Kong Prometheus right now until we deduplicate the metrics. You can try it but at your own risk. (To try you need to port-forward the Kong Prometheus to 8888)
+## Debugging information for Prometheus Federation 
+**Ignore** Do not do this block. This is simply for debugging purposed and ensuring you are federating the correct data. If you are looking to debug federation, you need to first port-forward the Kong Prometheus to 8888.
 ```
-# curl -v -G --data-urlencode 'match[]={job!=""}'  http://localhost:8888/federate
-
-# curl -v -G --data-urlencode 'match[]={job=~".+"}'  http://localhost:8888/federate 
-
-# curl -v -G --data-urlencode 'match[]={job=~"kubernetes-nodes-cadvisor"}'  http://localhost:8888/federate
-
 curl -v -G --data-urlencode 'match[]={job=~"kubernetes-service-endpoints",app_kubernetes_io_instance=~"kong-mesh"}'  http://localhost:8888/federate
 ```
-
-**Ignore** this block and do not copy and paste (WIP, more to come)
-```
-# take grafana out of the mesh
-kubectl patch deploy/grafana -n kong-mesh-metrics -p '{"spec": {"template":{"metadata":{"annotations":{"kuma.io/sidecar-injection":"false"}}}} }'
-```
-
-## Ignore Prometheus Sidecar
-insecure_skip_verify: true

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -302,7 +302,7 @@ oc port-forward svc/prometheus-operated -n openshift-monitoring 9090
 
 open [Prometheus Targets](http://localhost:9090/targets)
 
-do `ctrl-f` or whatever you do to search in your browser and search for `kong-federation`. May take about 30 seconds or so.
+do `ctrl-f` or whatever you do to search in your browser and search for `kong-federation`. May take about 30 seconds to become healthy.
 
 ## Create PrometheusRules
 Prom rules alert us when things go wrong/down. The simplest and most important prometheus rules that you can have are rules that trigger alerts when services go down and stay down. We are going to define just a few rules:  

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -1,0 +1,248 @@
+# Federate Kong Mesh Metrics
+in this document, we will federate the Kong Mesh Prometheus to the OpenShift Prometheus. We will then leverage OpenShift Monitoring to handle Kong Mesh metrics.
+
+**Pending**
+- [ ] Define more Params in `ServiceMonitor` to improve flow of data
+- [ ] Reduce Prometheus Metrics Usage with relabeling
+- [ ] Create PrometheusRules for Alerting when something goes down 
+- [ ] Create Dashboards    
+   
+**TOC**
+- [Install Kong Mesh](#install-kong-mesh)
+- [Configure Metrics](#configure-metrics)
+- [Create RBAC](#create-a-clusterrolebinding-to-allow-scraping)
+- [Federate Metrics to OpenShift Monitoring](#federate-metrics-to-openshift-monitoring)
+- [IGNORE- Test The Federate Endpoint of Kong Prometheus](#test-the-federate-endpoint-of-kong-prometheus)
+- [Make sure you are scraping Metrics](#make-sure-you-are-scraping-metrics)
+- [Clean Up](#clean-up)
+---
+## Install Kong Mesh
+- Download Kong Mesh
+```
+curl -L https://docs.konghq.com/mesh/installer.sh | sh -
+```
+
+a) Install control plane on kong-mesh-system namespace
+
+```{bash}
+./kumactl install control-plane --cni-enabled --license-path=./license | oc apply -f -
+oc get pod -n kong-mesh-system
+```
+
+- Expose the service
+
+```{bash}
+oc expose svc/kong-mesh-control-plane -n kong-mesh-system --port http-api-server
+```
+
+- Verify the Installation
+
+```{bash}
+http -h `oc get route kong-mesh-control-plane -n kong-mesh-system -ojson | jq -r .spec.host`/gui/
+```
+output
+```
+HTTP/1.1 200 OK
+accept-ranges: bytes
+cache-control: private
+content-length: 5962
+content-type: text/html; charset=utf-8
+date: Thu, 05 May 2022 15:56:54 GMT
+set-cookie: 559045d469a6cf01d61b4410371a08e0=1cb25fd8a600fb50f151da51bc64109c; path=/; HttpOnly
+```
+
+## Configure Metrics
+
+Note: If you have configured already the mTLS in your mesh, the default installation won't work because the Grafana
+deployment has an initContainer that pulls the dashboards from a github repository. )
+  
+_We are not using Grafana right now so lets just turn it off. We will worry about it when we are building dashboards_.
+
+- Apply scc  of non-root to ```kuma-metrics```
+```
+oc adm policy add-scc-to-group nonroot system:serviceaccounts:kong-mesh-metrics
+```
+
+Install metrics
+```
+./kumactl install metrics | kubectl apply -f -
+```
+- Turn off the Grafana deployment in `kong-mesh-metrics`
+```
+kubectl scale deploy/grafana -n kong-mesh-metrics --replicas=0
+```
+
+**Ignore** this block and do not copy and paste (WIP, more to come)
+```
+# take grafana out of the mesh
+kubectl patch deploy/grafana -n kong-mesh-metrics -p '{"spec": {"template":{"metadata":{"annotations":{"kuma.io/sidecar-injection":"false"}}}} }'
+```
+
+Configure the metrics in the existing mesh
+
+```{bash}
+kubectl apply -f -<<EOF
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin
+  metrics:
+    enabledBackend: prometheus-1
+    backends:
+    - name: prometheus-1
+      type: prometheus
+      conf:
+        port: 5670
+        path: /metrics
+        skipMTLS: false
+EOF
+```
+
+
+Remove the Sidecars (Still working through a more robust)
+```
+kubectl label ns kong-mesh-metrics kuma.io/sidecar-injection-
+
+kubectl delete po -n kong-mesh-metrics --force --grace-period=0 --all
+```
+
+## Create a ClusterroleBinding to Allow Scraping
+We need to allow the `prometheus-k8s` service account to scrape the `kong-mesh-metrics` resources
+
+
+Create Clusterrole
+```
+kubectl apply -f -<<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kong-prom
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - pods/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kong-prom-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kong-prom
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+EOF
+```
+
+Check Perms
+```
+k auth can-i get pods --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s
+
+k auth can-i get endpoints --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s
+
+k auth can-i get services --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s 
+```
+
+
+## Federate Metrics to OpenShift Monitoring
+Create a ServiceMonitor in OpenShift Monitoring to scrape from Kong
+```
+kubectl apply -f -<<EOF
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kong-federation
+  namespace: openshift-monitoring
+  labels:
+    app: kong-mesh
+spec:
+  jobLabel: exporter-kong-mesh
+  namespaceSelector:
+    matchNames:
+    - kong-mesh-metrics
+  selector:
+    matchLabels:
+      app: prometheus
+      component: server
+  endpoints:
+  - interval: 15s
+    scrapeTimeout: 15s
+    path: /federate
+    targetPort: 9090
+    port: http
+    params:
+      'match[]':
+      - '{job=~"kuma-dataplanes"}'
+      - '{job=~"kubernetes-nodes-cadvisor"}'
+    honorLabels: true
+EOF
+```
+
+
+
+Make sure logs are clean
+```
+k logs prometheus-k8s-1  -n openshift-monitoring --since=1m | grep kong-mesh-metrics
+```
+
+## Test The Federate Endpoint of Kong Prometheus
+**Ignore** Do not do this block, we are currently getting way too many metrics and need to filter down. This is effectively a DDoS attach on the Kong Prometheus right now until we filter down the metrics. You can try it but at your own risk. (To try you need to port-forward the Kong Prometheus to 8888)
+```
+# curl -v -G --data-urlencode 'match[]={job!=""}'  http://localhost:8888/federate
+
+# curl -v -G --data-urlencode 'match[]={job=~".+"}'  http://localhost:8888/federate 
+
+curl -v -G --data-urlencode 'match[]={job=~"kubernetes-nodes-cadvisor"}'  http://localhost:8888/federate
+```
+
+## Make sure you are scraping Metrics
+
+Go to the OpenShift Prometheus and try and Scrape metrics from Kong
+
+Go to Prom:
+```
+kubectl  port-forward svc/prometheus-operated  -n openshift-monitoring 9090 
+```
+
+open [prometheus locally](http://localhost:9090)
+
+Click *Targets* on the top Menu Bar
+
+do `ctrl-f` or whatever you do to search in your browser and search for `kong-federation`
+
+
+## Clean up
+
+- Uninstall metrics
+
+```bash
+kubectl delete servicemonitor -n openshift-monitoring kong-federation 
+kubectl delete mesh default
+oc adm policy remove-scc-from-group nonroot system:serviceaccounts:kong-mesh-metrics
+kumactl install metrics | kubectl delete -f -
+```
+
+- Uninstall kong mesh
+
+```bash
+kumactl install control-plane --cni-enabled --license-path=./license | kubectl delete -f -
+```

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -4,43 +4,48 @@ We will federate the Kong Mesh Prometheus to the OpenShift Prometheus. We will t
 **Pending**
 - [x] Define more Params in `ServiceMonitor` to dedupe metrics from Kong
 - [x] Create PrometheusRules for Alerting when something goes down 
-- [ ] Create Dashboards (Grafana Depricated, talk to team)
+- [x] Create Dashboards 
+- [ ] Scrape with mTLS enabled 
    
 **TOC**
 - [Install Kong Mesh](#install-kong-mesh)
+- [Kuma Demo Application](#kuma-demo-application)
 - [Configure Metrics](#configure-metrics)
 - [Create RBAC](#create-a-clusterrolebinding-to-allow-scraping)
 - [Federate Metrics to OpenShift Monitoring](#federate-metrics-to-openshift-monitoring)
-- [Make sure you are scraping Metrics](#make-sure-you-are-scraping-metrics)
+- [Verify you are scraping Metrics](#verify-you-are-scraping-metrics)
+- [Create Prom Rules](#create-prometheusrules)
+- [Create Grafana Dashboards](#create-grafana-dashboards)
 - [Clean Up](#clean-up)
 - [IGNORE- Test The Federate Endpoint of Kong Prometheus](#test-the-federate-endpoint-of-kong-prometheus)
 ---
+
 ## Install Kong Mesh
 - Download Kong Mesh
-```
+```bash
 curl -L https://docs.konghq.com/mesh/installer.sh | sh -
 ```
 
 a) Install control plane on kong-mesh-system namespace
 
-```{bash}
+```bash
 ./kumactl install control-plane --cni-enabled --license-path=./license | oc apply -f -
 oc get pod -n kong-mesh-system
 ```
 
 - Expose the service
 
-```{bash}
+```bash
 oc expose svc/kong-mesh-control-plane -n kong-mesh-system --port http-api-server
 ```
 
 - Verify the Installation
 
-```{bash}
+```bash
 http -h `oc get route kong-mesh-control-plane -n kong-mesh-system -ojson | jq -r .spec.host`/gui/
 ```
 output
-```
+```bash
 HTTP/1.1 200 OK
 accept-ranges: bytes
 cache-control: private
@@ -50,32 +55,111 @@ date: Thu, 05 May 2022 15:56:54 GMT
 set-cookie: 559045d469a6cf01d61b4410371a08e0=1cb25fd8a600fb50f151da51bc64109c; path=/; HttpOnly
 ```
 
+## Kuma Demo application
+
+- Apply scc of anyuid to kuma-demo
+```bash
+oc adm policy add-scc-to-group anyuid system:serviceaccounts:kuma-demo
+```
+
+- Install resources in kuma-demo ns
+```bash
+oc apply -f https://raw.githubusercontent.com/kumahq/kuma-demo/master/kubernetes/kuma-demo-aio.yaml
+```
+
+- Expose the frontend service
+
+```bash
+oc expose svc/frontend -n kuma-demo
+```
+
+- Validate the deployment
+
+```bash
+http -h `oc get route frontend -n kuma-demo -ojson | jq -r .spec.host` 
+```
+output
+```bash
+HTTP/1.1 200 OK
+cache-control: max-age=3600
+cache-control: private
+content-length: 862
+content-type: text/html; charset=UTF-8
+date: Tue, 10 May 2022 11:11:11 GMT
+etag: W/"251702827-862-2020-08-16T00:52:19.000Z"
+last-modified: Sun, 16 Aug 2020 00:52:19 GMT
+server: envoy
+set-cookie: 7132be541f54d5eca6de5be20e9063c8=d64fd1cc85da2d615f07506082000ef8; path=/; HttpOnly
+```
+
+- Check sidecar injection has been performed (NS has sidecar label)
+```bash
+oc -n kuma-demo get po -ojson | jq '.items[] | .spec.containers[] | .name'
+```
+output
+```bash
+"kuma-fe"
+"kuma-sidecar"
+"kuma-be"
+"kuma-sidecar"
+"master"
+"kuma-sidecar"
+"master"
+"kuma-sidecar"
+```
+
+- Enable mTLS and Traffic permissions
+```bash
+oc apply -f -<<EOF
+apiVersion: kuma.io/v1alpha1
+kind: Mesh
+metadata:
+  name: default
+spec:
+  mtls:
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin
+EOF
+
+# Check the frontend
+oc port-forward svc/frontend -n kuma-demo 8080
+```
+
+go to [localhost:8080](http://localhost:8080)
+
+Take down Redis in the `kong-demo` namespace (for Alert Demo)
+```bash
+oc scale deploy/redis-master --replicas=0 -n kuma-demo
+oc delete po --force --grace-period=0 -n redis-demo -l app=redis 
+```
 ## Configure Metrics
 
 Note: If you have configured already the mTLS in your mesh, the default installation won't work because the Grafana
-deployment has an initContainer that pulls the dashboards from a github repository. )
+deployment has an initContainer that pulls the dashboards from a github repository. 
   
-_We are not using Grafana right now so lets just turn it off. We will worry about it when we are building dashboards_.
+_We are not using Grafana right now so lets just turn it off_.
 
-- Apply scc  of non-root to ```kuma-metrics```
-```
+- Apply scc  of non-root to `kuma-metrics`
+```bash
 oc adm policy add-scc-to-group nonroot system:serviceaccounts:kong-mesh-metrics
 ```
 
 Install metrics
-```
-./kumactl install metrics | kubectl apply -f -
+```bash
+./kumactl install metrics | oc apply -f -
 ```
 - Turn off the Grafana deployment in `kong-mesh-metrics`
 ```
-kubectl scale deploy/grafana -n kong-mesh-metrics --replicas=0
+oc scale deploy/grafana -n kong-mesh-metrics --replicas=0
 ```
 
 
 Configure the metrics in the existing mesh
 
-```{bash}
-kubectl apply -f -<<EOF
+```bash
+oc apply -f -<<EOF
 apiVersion: kuma.io/v1alpha1
 kind: Mesh
 metadata:
@@ -94,25 +178,27 @@ spec:
       conf:
         port: 5670
         path: /metrics
-        skipMTLS: false
+        skipMTLS: true
 EOF
 ```
 
 
-Remove the Sidecars (Still working through a solution with sidecars)
-```
-kubectl label ns kong-mesh-metrics kuma.io/sidecar-injection-
+Remove the Sidecars (Still working through a solution with [sidecars](https://support.f5.com/csp/article/K03234274))
 
-kubectl delete po -n kong-mesh-metrics --force --grace-period=0 --all
+Strict mTLS is enabled, then Prometheus will need to be configured to scrape using  certificates. (WIP)
+```bash
+oc label ns kong-mesh-metrics kuma.io/sidecar-injection-
+
+oc delete po -n kong-mesh-metrics --force --grace-period=0 --all
 ```
 
 ## Create a ClusterroleBinding to Allow Scraping
-We need to allow the `prometheus-k8s` service account to scrape the `kong-mesh-metrics` resources
+We need to allow the `prometheus-k8s` service account to scrape the `kong-mesh-metrics` resources.
 
 
 Create Clusterrole
-```
-kubectl apply -f -<<EOF
+```bash
+oc apply -f -<<EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -147,22 +233,27 @@ subjects:
 EOF
 ```
 
-Check Perms
+Check permissions for prometheus-k8s service-account
+```bash
+oc auth can-i get pods --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s
+
+oc auth can-i get endpoints --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s
+
+oc auth can-i get services --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s 
 ```
-k auth can-i get pods --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s
-
-k auth can-i get endpoints --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s
-
-k auth can-i get services --namespace=kong-mesh-metrics --as system:serviceaccount:openshift-monitoring:prometheus-k8s 
+output
+```bash
+yes
+yes
+yes
 ```
-
 
 ## Federate Metrics to OpenShift Monitoring
-A `ServiceMonitor` is meant to tell Prometheus what metrics to scrape. Typically we use a `ServiceMonitor` or `PodMonitor` per application. Another thing that a ServiceMonitor can do is define a prometheus instance for federation.    
+A `ServiceMonitor` is meant to tell Prometheus what metrics to scrape. Typically we use a `ServiceMonitor` or `PodMonitor` per application. Another thing that a ServiceMonitor can do is federate a prometheus instance.    
    
-Create a ServiceMonitor in OpenShift Monitoring to scrape Kong Metrics
-```
-kubectl apply -f -<<EOF
+Create a ServiceMonitor in OpenShift Monitoring to federate Kong Metrics
+```bash
+oc apply -f -<<EOF
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -181,7 +272,7 @@ spec:
       component: server
   endpoints:
   - interval: 2s # we should use 30 seconds (only for demo)
-    scrapeTimeout: 2s # we should use 30 seconds (only for demo)
+    scrapeTimeout: 2s # we should use 30 seconds (not a sane default)
     path: /federate
     targetPort: 9090
     port: http
@@ -196,32 +287,36 @@ EOF
 
 
 Make sure OCP Prom logs are clean
-```
-kubectl logs prometheus-k8s-1  -n openshift-monitoring --since=1m | grep kong-mesh-metrics
+```bash
+oc logs prometheus-k8s-1  -n openshift-monitoring --since=1m | grep kong-mesh-metrics
 ```
 
-## Make sure you are scraping Metrics
-
-Go to the OpenShift Prometheus and try and Scrape metrics from Kong
+## Verify you are scraping Metrics
+Go to the OpenShift Prometheus and take a look at the targets
 
 Go to Prom:
-```
-kubectl  port-forward svc/prometheus-operated  -n openshift-monitoring 9090 
+```bash
+oc port-forward svc/prometheus-operated -n openshift-monitoring 9090 
 ```
 
 open [Prometheus Targets](http://localhost:9090/targets)
 
-do `ctrl-f` or whatever you do to search in your browser and search for `kong-federation`
+do `ctrl-f` or whatever you do to search in your browser and search for `kong-federation`. May take about 30 seconds or so.
 
 ## Create PrometheusRules
-Prom rules alert us when things go wrong. The simplest and most important prometheus rules that you can have are rules that trigger alerts when services go down and stay down. We are going to define two rules:  
-1. Alert when ControlPlane goes down
-2. Alert when Federation goes down (Kong's Prom Server is down)
+Prom rules alert us when things go wrong/down. The simplest and most important prometheus rules that you can have are rules that trigger alerts when services go down and stay down. We are going to define just a few rules:  
+   
+1. ControlPlane Down
+2. Federation Down (Kong's Prom Server is down)
+3. Kong Demo Backend Down
+4. Kong Demo Frontend Down
+5. Kond Demo Postgres Down
+6. Kong Demo Redis Down
 
 
-Lets create the PromRule
-```
-kubectl apply -f -<<EOF
+Lets create the PromRule(s)
+```bash
+oc apply -f -<<EOF
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -231,13 +326,47 @@ metadata:
   namespace: openshift-monitoring
 spec:
   groups:
+  - name: dataplane-rules
+    rules:
+    - alert: KongDemoBackendDown
+      annotations:
+        description: Demo Backend pod has not been ready the defined time period.
+        summary: Demo Backend is down.
+      expr: absent(up{app="kuma-demo-backend",job="kuma-dataplanes"} == 1)
+      for: 60s
+      labels:
+        severity: critical
+    - alert: KongDemoFrontendDown
+      annotations:
+        description: Demo Frontend pod has not been ready the defined time period.
+        summary: Demo Frontend is down.
+      expr: absent(up{app="kuma-demo-frontend",job="kuma-dataplanes"} == 1)
+      for: 5s
+      labels:
+        severity: critical
+    - alert: KongDemoDBDown
+      annotations:
+        description: Demo DB pod has not been ready the defined time period.
+        summary: Demo DB is down.
+      expr: absent(up{app="postgres",job="kuma-dataplanes"} == 1)
+      for: 5s
+      labels:
+        severity: critical
+    - alert: KongDemoCacheDown
+      annotations:
+        description: Demo Cache pod has not been ready the defined time period.
+        summary: Demo Cache is down.
+      expr: absent(up{app="redis",job="kuma-dataplanes"} == 1)
+      for: 5s
+      labels:
+        severity: critical
   - name: mesh-rules
     rules:
     - alert: KongControlPlaneDown
       annotations:
         description: ControlPlane pod has not been ready for over a minute.
         summary: CP is down.
-      expr: absent(kube_pod_container_status_ready{container="control-plane", endpoint="https-main", job="kube-state-metrics", namespace="kong-mesh-system",service="kube-state-metrics"})
+      expr: absent(kube_pod_container_status_ready{namespace="kong-mesh-system"})
       for: 5s
       labels:
         severity: critical
@@ -252,98 +381,215 @@ spec:
 EOF
 ```
 
-We want to be alerted when a critical service goes down, so lets test the alert to make sure we will be notified when these incidents occur.
+We want to be alerted when a critical service goes down, so lets test the alert to make sure we will be notified when these incidents occur. To keep this brief, we will only test the `KongDemoCacheDown` rule.
 
-**Take down the Kong ControlPlane**
-```
-kubectl scale deploy -n kong-mesh-system --replicas=0 --all
-kubectl delete po -n kong-mesh-system --all --force --grace-period=0
-```
-
-**Take down the Kong Prometheus Server**
-```
-kubectl scale deploy/prometheus-server --replicas=0 -n kong-mesh-metrics
-kubectl delete po -n kong-mesh-metrics --force --grace-period=0 -l app=prometheus
+**Take down the the Cache in Kuma Demo**
+```bash
+oc scale deploy/redis-master -n kuma-demo --replicas=0
+oc delete pod --force --grace-period=0 -l app=redis -n kuma-demo
 ```
 
-Port-forward OpenShift Metric's Prom Service
-```
-kubectl  port-forward svc/prometheus-operated  -n openshift-monitoring 9090 
-```
-Lets check the [alerts](http://localhost:9090/alerts), this may take over a minute to two to reflect the alerts. Alerts go from pending to firing.
-
-also, you can check the alerts by curling them
-```
-curl http://localhost:9090/api/v1/query\?query\=ALERTS | jq 
+**Check the Alerts in the OpenShift Prometheus**
+Go to Prom and wait until you see the alert for `KongDemoCacheDown`
+```bash
+oc port-forward svc/prometheus-operated -n openshift-monitoring 9090 
 ```
 
-output
-```
-      {
-        "metric": {
-          "__name__": "ALERTS",
-          "alertname": "KongControlPlaneDown",
-          "alertstate": "firing",
-          "container": "control-plane",
-          "endpoint": "https-main",
-          "job": "kube-state-metrics",
-          "namespace": "kong-mesh-system",
-          "service": "kube-state-metrics",
-          "severity": "critical"
-        },
-        "value": [
-          1651865684.46,
-          "1"
-        ]
-      },
-      {
-        "metric": {
-          "__name__": "ALERTS",
-          "alertname": "KongMetricsDown",
-          "alertstate": "firing",
-          "container": "prometheus-server",
-          "namespace": "kong-mesh-metrics",
-          "severity": "critical"
-        },
-        "value": [
-          1651865684.46,
-          "1"
-        ]
-      },
-```
+open [Prometheus Alerts](http://localhost:9090/alerts)
 
 **Bring up the Kong ControlPlane and Kong Prometheus Server**
+```bash
+oc scale deploy/redis-master -n kuma-demo --replicas=1
 ```
-kubectl scale deploy -n kong-mesh-system --replicas=1 --all
-
-kubectl scale deploy/prometheus-server --replicas=1 -n kong-mesh-metrics
-```
-## Create a Grafana Dashboard 
-Since Grafana is now depricated in OCP 4.10, i recommend installing the Grafana Operator for ease of use.
+## Create Grafana Dashboards
+Since Grafana is now depricated in OCP 4.10, we are using the Grafana Operator for ease of use and configuration.
 
 https://access.redhat.com/solutions/6615991
 
+Create the Grafana namespace
+```bash
+oc apply -f -<<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: grafana
+spec: {}
+status: {}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: grafana
+  namespace: grafana
+spec:
+  targetNamespaces:
+  - grafana
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/grafana-operator.grafana: ""
+  name: grafana-operator
+  namespace: grafana
+spec:
+  channel: v4
+  installPlanApproval: Automatic
+  name: grafana-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: grafana-operator.v4.4.1
+EOF
+```
+
+Wait for Grafana to become ready
+```bash
+oc wait --for=condition=Ready --timeout=180s pod -l control-plane=controller-manager -n grafana
+```
+
+Create an instance of Grafana
+```bash
+oc apply -f -<<EOF
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: grafana
+  namespace: grafana
+spec:
+  baseImage: grafana/grafana:8.3.3 # same as Kong's Grafana
+  client:
+    preferService: true
+  config:
+    security:
+      admin_user: "admin"
+      admin_password: "admin"
+    users:
+      viewers_can_edit: True
+    log:
+      mode: "console"
+      level: "error"
+    log.frontend:
+      enabled: true
+    auth:
+      disable_login_form: True
+      disable_signout_menu: True
+    auth.anonymous:
+      enabled: True
+  service:
+    name: "grafana-service"
+    labels:
+      app: "grafana"
+      type: "grafana-service"
+  dashboardLabelSelector:
+    - matchExpressions:
+        - { key: app, operator: In, values: [grafana] }
+  resources:
+    # Optionally specify container resources
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+EOF
+```
+
+*Connect Prometheus to Grafana*
+- Grant `grafana-serviceaccount` cluster-monitoring-view clusterrole.
+- Get Bearer Token from `grafana-serviceaccount`
+- Create an instance of `GrafanaDataSource` with Bearer Token
+
+```bash
+oc apply -f -<<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: grafana-serviceaccount
+  namespace: grafana
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: prometheus-grafanadatasource
+  namespace: grafana
+spec:
+  datasources:
+    - access: proxy
+      editable: true
+      isDefault: true
+      jsonData:
+        httpHeaderName1: 'Authorization'
+        timeInterval: 5s
+        tlsSkipVerify: true
+      name: Prometheus
+      secureJsonData:
+        httpHeaderValue1: 'Bearer $(oc serviceaccounts get-token grafana-serviceaccount -n grafana)'
+      type: prometheus
+      url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
+  name: prometheus-grafanadatasource.yaml
+EOF
+```
+
+Create the Dashboards
+```bash
+oc apply -f mesh/dashboards
+```
+
+Bring up the Grafana Instance
+```bash
+oc port-forward svc/grafana-service 3000 -n grafana 
+```
+open [Grafana](http://localhost:3000)
+
 ## Clean up
 
+- Clean up Grafana 
+```bash
+oc delete grafanadashboard,grafanadatasource,grafana -n grafana --all --force --grace-period=0
+
+oc delete subs,og,csv -n grafana --all --force --grace-period=0
+```
+
+- Uninstall Demo App
+```bash
+oc delete -f https://raw.githubusercontent.com/kumahq/kuma-demo/master/kubernetes/kuma-demo-aio.yaml
+
+oc adm policy remove-scc-from-group anyuid system:serviceaccounts:kuma-demo
+
+oc delete routes -n kuma-demo --force --all
+oc delete mesh default
+```
 - Uninstall metrics
 
 ```bash
-kubectl delete servicemonitor -n openshift-monitoring kong-federation 
-kubectl delete prometheusrules -n openshift-monitoring mesh-rules
-kubectl delete mesh default
+oc delete servicemonitor -n openshift-monitoring kong-federation 
+oc delete prometheusrules -n openshift-monitoring mesh-rules
+oc delete mesh default
 oc adm policy remove-scc-from-group nonroot system:serviceaccounts:kong-mesh-metrics
-kumactl install metrics | kubectl delete -f -
+kumactl install metrics | oc delete -f -
+oc delete pvc,po --force --grace-period=0 --all -n kong-mesh-metrics
 ```
 
 - Uninstall kong mesh
 
 ```bash
-kumactl install control-plane --cni-enabled --license-path=./license | kubectl delete -f -
+kumactl install control-plane --cni-enabled --license-path=./license | oc delete -f -
+sleep 3;
+oc delete po,pvc --all -n kong-mesh-system --force --grace-period=0
 ```
 
 
 ## Test The Federate Endpoint of Kong Prometheus
-**Ignore** Do not do this block, we are currently getting way too many metrics and need to filter down. This is effectively a DDoS attach on the Kong Prometheus right now until we deduplicate the metrics. You can try it but at your own risk. (To try you need to port-forward the Kong Prometheus to 8888)
+**Ignore** Do not do this block, we are currently getting way too many metrics and need to filter down. This is effectively a DDoS attack on the Kong Prometheus right now until we deduplicate the metrics. You can try it but at your own risk. (To try you need to port-forward the Kong Prometheus to 8888)
 ```
 # curl -v -G --data-urlencode 'match[]={job!=""}'  http://localhost:8888/federate
 
@@ -359,3 +605,6 @@ curl -v -G --data-urlencode 'match[]={job=~"kubernetes-service-endpoints",app_ku
 # take grafana out of the mesh
 kubectl patch deploy/grafana -n kong-mesh-metrics -p '{"spec": {"template":{"metadata":{"annotations":{"kuma.io/sidecar-injection":"false"}}}} }'
 ```
+
+## Ignore Prometheus Sidecar
+insecure_skip_verify: true

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -129,7 +129,7 @@ oc port-forward svc/frontend -n kuma-demo 8080
 
 go to [localhost:8080](http://localhost:8080)
 
-Take down Redis in the `kong-demo` namespace (for Alert Demo)
+Take down Redis in the `kuma-demo` namespace (for Alert Demo)
 ```bash
 oc scale deploy/redis-master --replicas=0 -n kuma-demo
 oc delete po --force --grace-period=0 -n kuma-demo -l app=redis 
@@ -383,7 +383,7 @@ EOF
 
 We want to be alerted when a critical service goes down, so lets test the alert to make sure we will be notified when these incidents occur. To keep this brief, we will only test the `KongDemoCacheDown` rule.
 
-**Take down the the Cache in Kuma Demo**
+**Take down the Cache in Kuma Demo**
 ```bash
 oc scale deploy/redis-master -n kuma-demo --replicas=0
 oc delete pod --force --grace-period=0 -l app=redis -n kuma-demo
@@ -397,7 +397,7 @@ oc port-forward svc/prometheus-operated -n openshift-monitoring 9090
 
 open [Prometheus Alerts](http://localhost:9090/alerts)
 
-**Bring up the Kong ControlPlane and Kong Prometheus Server**
+**Bring up the Cache in Kuma Demor**
 ```bash
 oc scale deploy/redis-master -n kuma-demo --replicas=1
 ```
@@ -573,7 +573,6 @@ oc delete mesh default
 ```bash
 oc delete servicemonitor -n openshift-monitoring kong-federation 
 oc delete prometheusrules -n openshift-monitoring mesh-rules
-oc delete mesh default
 oc adm policy remove-scc-from-group nonroot system:serviceaccounts:kong-mesh-metrics
 kumactl install metrics | oc delete -f -
 oc delete pvc,po --force --grace-period=0 --all -n kong-mesh-metrics
@@ -589,7 +588,6 @@ oc delete po,pvc --all -n kong-mesh-system --force --grace-period=0
 
 # Gotchas
 - in Grafana Dashboards, Prometheus DataSource `uid` must be `Prometheus` with Capital "P". 
-- Make sure you are using the same version of Grafana in the operator as Kong
 
 
 ## Test The Federate Endpoint of Kong Prometheus

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -132,7 +132,7 @@ go to [localhost:8080](http://localhost:8080)
 Take down Redis in the `kong-demo` namespace (for Alert Demo)
 ```bash
 oc scale deploy/redis-master --replicas=0 -n kuma-demo
-oc delete po --force --grace-period=0 -n redis-demo -l app=redis 
+oc delete po --force --grace-period=0 -n kuma-demo -l app=redis 
 ```
 ## Configure Metrics
 
@@ -586,6 +586,10 @@ kumactl install control-plane --cni-enabled --license-path=./license | oc delete
 sleep 3;
 oc delete po,pvc --all -n kong-mesh-system --force --grace-period=0
 ```
+
+# Gotchas
+- in Grafana Dashboards, Prometheus DataSource `uid` must be `Prometheus` with Capital "P". 
+- Make sure you are using the same version of Grafana in the operator as Kong
 
 
 ## Test The Federate Endpoint of Kong Prometheus

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -194,6 +194,11 @@ spec:
       - '{job=~"kuma-dataplanes"}'
       - '{job=~"kubernetes-nodes-cadvisor"}'
     honorLabels: true
+#    metricRelabelings:
+#    - sourceLabels: ["__name__"]
+#      regex: 'workload:(.*)'
+#      targetLabel: "__name__"
+#      action: replace
 EOF
 ```
 
@@ -205,7 +210,7 @@ k logs prometheus-k8s-1  -n openshift-monitoring --since=1m | grep kong-mesh-met
 ```
 
 ## Test The Federate Endpoint of Kong Prometheus
-**Ignore** Do not do this block, we are currently getting way too many metrics and need to filter down. This is effectively a DDoS attach on the Kong Prometheus right now until we filter down the metrics. You can try it but at your own risk. (To try you need to port-forward the Kong Prometheus to 8888)
+**Ignore** Do not do this block, we are currently getting way too many metrics and need to filter down. This is effectively a DDoS attach on the Kong Prometheus right now until we deduplicate the metrics. You can try it but at your own risk. (To try you need to port-forward the Kong Prometheus to 8888)
 ```
 # curl -v -G --data-urlencode 'match[]={job!=""}'  http://localhost:8888/federate
 
@@ -225,7 +230,7 @@ kubectl  port-forward svc/prometheus-operated  -n openshift-monitoring 9090
 
 open [prometheus locally](http://localhost:9090)
 
-Click *Targets* on the top Menu Bar
+Click Status, then *Targets* on the top Menu Bar
 
 do `ctrl-f` or whatever you do to search in your browser and search for `kong-federation`
 

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -403,7 +403,7 @@ open [Prometheus Alerts](http://localhost:9090/alerts)
 oc scale deploy/redis-master -n kuma-demo --replicas=1
 ```
 ## Create Grafana Dashboards
-Since Grafana is now depricated in OCP 4.10, we are using the Grafana Operator for ease of use and configuration.
+Since Grafana is now deprecated in OCP 4.10, we are using the Grafana Operator for ease of use and configuration.
 
 https://access.redhat.com/solutions/6615991
 

--- a/kong-mesh-federation.md
+++ b/kong-mesh-federation.md
@@ -413,7 +413,6 @@ oc apply -f -<<EOF
 apiVersion: v1
 kind: Namespace
 metadata:
-  creationTimestamp: null
   name: grafana
 spec: {}
 status: {}

--- a/mesh/dashboards/kong-mesh-opa.yaml
+++ b/mesh/dashboards/kong-mesh-opa.yaml
@@ -1,0 +1,632 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: kong-mesh-opa
+  namespace: grafana
+spec:
+  datasources:
+  - datasourceName: prometheus-grafanadatasource
+    inputName: middleware.yaml
+  json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+            },
+            "type": "dashboard"
+        }
+        ]
+    },
+    "description": "Statistics of a single Dataplane in Kuma Service Mesh",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": 11775,
+    "graphTooltip": 0,
+    "id": 1,
+    "iteration": 1652205342933,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+        },
+        "id": 10,
+        "panels": [],
+        "title": "Dataplane",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 1
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:1022",
+            "alias": "/OK.*/",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:1030",
+            "alias": "/Error.*/",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:1038",
+            "alias": "/Denied.*/",
+            "color": "#FF9830"
+            },
+            {
+            "$$hashKey": "object:1096",
+            "alias": "/Disabled.*/",
+            "color": "#5794F2"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "irate(envoy_http_ext_authz_denied{dataplane=\"$dataplane\",mesh=\"$mesh\"}[1m])",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Denied - {{ envoy_http_conn_manager_prefix }}",
+            "refId": "A"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_ok{dataplane=\"$dataplane\",mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "OK - {{ envoy_http_conn_manager_prefix }}",
+            "refId": "B"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_disabled{dataplane=\"$dataplane\",mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "Disabled - {{ envoy_http_conn_manager_prefix }}",
+            "refId": "C"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_error{dataplane=\"$dataplane\",mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "Error - {{ envoy_http_conn_manager_prefix }}",
+            "refId": "D"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_failure_mode_allowed{dataplane=\"$dataplane\",mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "Failure mode allowed - {{ envoy_http_conn_manager_prefix }}",
+            "refId": "E"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "External Authorization decisions on incoming HTTP requests to selected data plane proxy",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:651",
+            "format": "reqps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:652",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 10
+        },
+        "id": 15,
+        "panels": [],
+        "title": "Service",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 13,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:1022",
+            "alias": "/OK.*/",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:1030",
+            "alias": "/Error.*/",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:1038",
+            "alias": "/Denied.*/",
+            "color": "#FF9830"
+            },
+            {
+            "$$hashKey": "object:1096",
+            "alias": "/Disabled.*/",
+            "color": "#5794F2"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "irate(envoy_http_ext_authz_denied{mesh=\"$mesh\",kuma_io_service=\"$service\"}[1m])",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Denied - {{ dataplane }}",
+            "refId": "A"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_ok{mesh=\"$mesh\",kuma_io_service=\"$service\"}[1m])",
+            "interval": "",
+            "legendFormat": "OK - {{ dataplane }}",
+            "refId": "B"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_disabled{mesh=\"$mesh\",kuma_io_service=\"$service\"}[1m])",
+            "interval": "",
+            "legendFormat": "Disabled - {{ dataplane }}",
+            "refId": "C"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_error{mesh=\"$mesh\",kuma_io_service=\"$service\"}[1m])",
+            "interval": "",
+            "legendFormat": "Error - {{ dataplane }}",
+            "refId": "D"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_failure_mode_allowed{mesh=\"$mesh\",kuma_io_service=\"$service\"}[1m])",
+            "interval": "",
+            "legendFormat": "Failure mode allowed - {{ dataplane }}",
+            "refId": "E"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "External Authorization decisions on incoming HTTP requests to the all plane proxies of selected service",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:651",
+            "format": "reqps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:652",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+        },
+        "id": 12,
+        "panels": [],
+        "title": "Mesh",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 21
+        },
+        "hiddenSeries": false,
+        "id": 16,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:1022",
+            "alias": "/OK.*/",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:1030",
+            "alias": "/Error.*/",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:1038",
+            "alias": "/Denied.*/",
+            "color": "#FF9830"
+            },
+            {
+            "$$hashKey": "object:1096",
+            "alias": "/Disabled.*/",
+            "color": "#5794F2"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "irate(envoy_http_ext_authz_denied{mesh=\"$mesh\"}[1m])",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Denied - {{ kuma_io_service }}",
+            "refId": "A"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_ok{mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "OK - {{ kuma_io_service }}",
+            "refId": "B"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_disabled{mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "Disabled - {{ kuma_io_service }}",
+            "refId": "C"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_error{mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "Error - {{ kuma_io_service }}",
+            "refId": "D"
+            },
+            {
+            "expr": "irate(envoy_http_ext_authz_failure_mode_allowed{mesh=\"$mesh\"}[1m])",
+            "interval": "",
+            "legendFormat": "Failure mode allowed - {{ kuma_io_service }}",
+            "refId": "E"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "External Authorization decisions on incoming HTTP requests to the all plane proxies in selected Mesh",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:651",
+            "format": "reqps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:652",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        }
+    ],
+    "schemaVersion": 34,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": false,
+            "text": "default",
+            "value": "default"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live, mesh)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Mesh",
+            "multi": false,
+            "name": "mesh",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live, mesh)",
+            "refId": "Prometheus-mesh-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "current": {
+            "selected": false,
+            "text": "backend_kuma-demo_svc_3001",
+            "value": "backend_kuma-demo_svc_3001"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Service",
+            "multi": false,
+            "name": "service",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "refId": "Prometheus-service-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "current": {
+            "selected": false,
+            "text": "kuma-demo-backend-v0-56db47c579-hhjn6.kuma-demo",
+            "value": "kuma-demo-backend-v0-56db47c579-hhjn6.kuma-demo"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_service=\"$service\"}, dataplane)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Dataplane",
+            "multi": false,
+            "name": "dataplane",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_service=\"$service\"}, dataplane)",
+            "refId": "Prometheus-dataplane-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-5m",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "Kong Mesh OPA",
+    "uid": "EvaPUNPGz",
+    "version": 1,
+    "weekStart": ""
+    }

--- a/mesh/dashboards/kuma-cp.yaml
+++ b/mesh/dashboards/kuma-cp.yaml
@@ -1,0 +1,3768 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: kuma-cp
+  namespace: grafana
+spec:
+  datasources:
+  - datasourceName: prometheus-grafanadatasource
+    inputName: middleware.yaml
+  json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+            },
+            "type": "dashboard"
+        }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 2,
+    "iteration": 1652203821892,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+        },
+        "id": 44,
+        "panels": [],
+        "title": "Overview",
+        "type": "row"
+        },
+        {
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "from": 1,
+                    "result": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "LIVE"
+                    },
+                    "to": 9999
+                },
+                "type": "range"
+                },
+                {
+                "options": {
+                    "from": 0,
+                    "result": {
+                    "color": "red",
+                    "index": 1,
+                    "text": "UNAVAILABLE"
+                    },
+                    "to": 0.999
+                },
+                "type": "range"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "red",
+                    "value": null
+                },
+                {
+                    "color": "green",
+                    "value": 1
+                }
+                ]
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 1
+        },
+        "id": 39,
+        "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+            "calcs": [
+                "last"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(cp_info{instance=~\"$instance\"} OR on() vector(0))",
+            "instant": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+            }
+        ],
+        "title": "Condition",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+            },
+            "mappings": [],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 6,
+            "y": 1
+        },
+        "id": 41,
+        "maxDataPoints": 1,
+        "options": {
+            "footer": {
+            "fields": "",
+            "reducer": [
+                "sum"
+            ],
+            "show": false
+            },
+            "showHeader": true
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "cp_info{instance=~\"$instance\"}",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+            }
+        ],
+        "title": "Control Plane information",
+        "transformations": [
+            {
+            "id": "labelsToFields",
+            "options": {}
+            },
+            {
+            "id": "merge",
+            "options": {}
+            },
+            {
+            "id": "organize",
+            "options": {
+                "excludeByName": {
+                "Time": true,
+                "Value": true,
+                "build_date": true,
+                "cluster_id": true,
+                "git_commit": true,
+                "git_tag": true,
+                "job": true,
+                "kubernetes_name": true,
+                "kubernetes_namespace": true,
+                "kubernetes_node": true,
+                "product": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                "instance": "Instance",
+                "instance_id": "Instance ID",
+                "mode": "Mode",
+                "version": "Version"
+                }
+            }
+            },
+            {
+            "id": "merge",
+            "options": {}
+            }
+        ],
+        "type": "table"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Only one instance should be a leader at a given point of time in every zone",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 1
+        },
+        "hiddenSeries": false,
+        "id": 68,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum by (zone, instance) (leader)",
+            "interval": "",
+            "legendFormat": "{{ zone }} - {{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Leader",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:3281",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:3282",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+        },
+        "id": 16,
+        "panels": [],
+        "title": "Aggregated Discovery Service (XDS): CP-DP communication",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 20,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "xds_streams_active{instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "XDS active connections",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:258",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:259",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "Number of ADS messages exchanged between Control Plane and Dataplane over XDS",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 4,
+            "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 18,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:630",
+            "alias": "Configuration sent",
+            "color": "#5794F2"
+            },
+            {
+            "$$hashKey": "object:631",
+            "alias": "Configuration accepted",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:632",
+            "alias": "Configuration rejected",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:633",
+            "alias": "RPC Errors",
+            "color": "#C4162A"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(xds_responses_sent{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Configuration sent",
+            "refId": "A"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(xds_requests_received{confirmation=\"ACK\",instance=~\"$instance\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Configuration accepted",
+            "refId": "B"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(xds_requests_received{confirmation=\"NACK\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Configuration rejected",
+            "refId": "C"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(grpc_server_handled_total{grpc_service=\"envoy.service.discovery.v3.AggregatedDiscoveryService\",grpc_code!=\"OK\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "RPC Errors",
+            "refId": "D"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(grpc_server_started_total{grpc_service=\"envoy.service.discovery.v3.AggregatedDiscoveryService\",instance=~\"$instance\"}[1m]))",
+            "hide": true,
+            "interval": "",
+            "legendFormat": "Rate",
+            "refId": "E"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "XDS message exchange",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:458",
+            "format": "ops",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:459",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Number of Envoy XDS config generations per second. Config is sent only when it's different than previously generated. The value should be the number of connected dataplanes * KUMA_XDS_SERVER_DATAPLANE_CONFIGURATION_REFRESH_INTERVAL",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 9,
+            "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 28,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:1365",
+            "alias": "Errors",
+            "color": "#F2495C"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(xds_generation_count{instance=~\"$instance\"}[1m])) - sum(rate(xds_generation_errors{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Success",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(xds_generation_errors{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Errors",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "XDS config generations",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:456",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:457",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "How much it took to generate Envoy configuration for a single dataplane",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 14,
+            "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 24,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "xds_generation{quantile=\"0.99\",instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency of XDS config generation (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:309",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:310",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "How much it took to deliver Envoy configuration and receive ACK/NACK for a single dataplane",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 19,
+            "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 82,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "xds_delivery{quantile=\"0.99\",instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency of XDS config delivery (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:309",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:310",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Cache protects ClusterLoadAssignments resources by sharing them between many goroutines which reconcile Dataplanes.\n\nhit - request was retrieved from the cache.\n\nhit-wait - request was retrieved from the cache after waiting for a concurrent request to fetch it from the database.\n\nmiss - request was fetched from the database\n\nRefer to https://kuma.io/docs/latest/documentation/fine-tuning/#snapshot-generation",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 13,
+            "x": 0,
+            "y": 18
+        },
+        "hiddenSeries": false,
+        "id": 70,
+        "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": true,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(cla_cache{result=\"hit\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Hit",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(cla_cache{result=\"hit-wait\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Hit Wait",
+            "refId": "C"
+            },
+            {
+            "expr": "sum(rate(cla_cache{result=\"miss\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Miss",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Endpoints cache performance",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:645",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:646",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Mesh Cache protects hashes calculated periodically for each Mesh in order to avoid the excessive generation of xDS resources.\n\nhit - request was retrieved from the cache.\n\nhit-wait - request was retrieved from the cache after waiting for a concurrent request to fetch it from the database.\n\nmiss - request was fetched from the database\n\nRefer to https://kuma.io/docs/latest/documentation/fine-tuning/#snapshot-generation",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 11,
+            "x": 13,
+            "y": 18
+        },
+        "hiddenSeries": false,
+        "id": 71,
+        "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": true,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(mesh_cache{result=\"hit\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Hit",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(mesh_cache{result=\"hit-wait\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Hit Wait",
+            "refId": "C"
+            },
+            {
+            "expr": "sum(rate(mesh_cache{result=\"miss\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Miss",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Mesh resources hash cache performance",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:645",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:646",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 26
+        },
+        "id": 73,
+        "panels": [],
+        "title": "Health Discovery Service (HDS): CP-DP communication",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 75,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(hds_responses_sent{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "endpoint health responses",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(hds_requests_received{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "health check requests",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "HDS message exchange",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:310",
+            "format": "ops",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:311",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 77,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "hds_streams_active{instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "HDS active connections",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:797",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:798",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "Number of Envoy HDS config generations per second. Config is sent only when it's different than previously generated. The value should be the number of connected dataplanes * KUMA_DP_SERVER_HDS_REFRESH_INTERVAL",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 79,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:1727",
+            "alias": "Errors",
+            "color": "#F2495C"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "expr": "sum(rate(hds_generation_count{instance=~\"$instance\"}[1m])) - sum(rate(hds_generation_errors{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Success",
+            "refId": "A"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(hds_generation_errors{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Errors",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "HDS config generations",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1493",
+            "format": "ops",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1494",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "How much it took to generate Envoy configuration for a single dataplane",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 27
+        },
+        "hiddenSeries": false,
+        "id": 81,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "hds_generation{quantile=\"0.99\",instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency of HDS config generation (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1825",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1826",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 35
+        },
+        "id": 5,
+        "panels": [],
+        "title": "API Server - Management of the Control Plane",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 0,
+            "y": 36
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "histogram_quantile(0.99, sum by (handler, le) (rate(api_server_http_request_duration_seconds_bucket{instance=~\"$instance\"}[1m])))",
+            "interval": "",
+            "legendFormat": "{{handler}}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency of API Server Requests (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:853",
+            "format": "s",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:854",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 36
+        },
+        "hiddenSeries": false,
+        "id": 9,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:695",
+            "alias": "/2.*/",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:696",
+            "alias": "/4.*/",
+            "color": "#FADE2A"
+            },
+            {
+            "$$hashKey": "object:697",
+            "alias": "/5.*/",
+            "color": "#F2495C"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum by (code) (rate(api_server_http_request_duration_seconds_count{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Response Codes",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:796",
+            "format": "cps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:797",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 44
+        },
+        "id": 54,
+        "panels": [],
+        "title": "Dataplane Server: CP-DP communication",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "XDS and SDS requests are not taken into account because they are long-running requests",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 0,
+            "y": 45
+        },
+        "hiddenSeries": false,
+        "id": 55,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "histogram_quantile(0.99, sum by (handler, le) (rate(dp_server_http_request_duration_seconds_bucket{instance=~\"$instance\"}[1m])))",
+            "interval": "",
+            "legendFormat": "{{handler}}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency of Dataplane Server Requests (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:853",
+            "format": "s",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:854",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "XDS and SDS requests are not taken into account because they are long-running requests",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 45
+        },
+        "hiddenSeries": false,
+        "id": 56,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:695",
+            "alias": "/2.*/",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:696",
+            "alias": "/4.*/",
+            "color": "#FADE2A"
+            },
+            {
+            "$$hashKey": "object:697",
+            "alias": "/5.*/",
+            "color": "#F2495C"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum by (code) (rate(dp_server_http_response_size_bytes_count{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Response Codes",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:796",
+            "format": "cps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:797",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 52
+        },
+        "id": 26,
+        "panels": [],
+        "title": "Kuma Discovery Service (KDS) - Mutltizone communication",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "This metric presents if policies are properly propagated from Global to Zones. All instances of global and zones in the system should have the same number of policies. This metric have additional latency of 1 minute (it is not computed on the fly when scraping is done)",
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 53
+        },
+        "hiddenSeries": false,
+        "id": 61,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum by (zone, instance) (resources_count{instance=~\"$instance\",resource_type!~\"Dataplane|DataplaneInsight|Zone|ZoneInsight|ZoneIngress|ZoneIngressInsight|ZoneEgress|ZoneEgressInsight\"})",
+            "interval": "",
+            "legendFormat": "{{ zone }} - {{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Policies count (sync check)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:534",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:535",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "This metric presents if Dataplanes are properly propagated from Zones to Global. Keep in mind that Dataplanes from all zones != Dataplanes from global. All zones receive additional one dataplane of Ingress from other Zones. This metric have additional latency of 1 minute (it is not computed on the fly when scraping is done)",
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 53
+        },
+        "hiddenSeries": false,
+        "id": 66,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum by (zone, instance) (resources_count{instance=~\"$instance\",resource_type=\"Dataplane\"})",
+            "interval": "",
+            "legendFormat": "{{ zone }} - {{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Dataplane count",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:534",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:535",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Number of zone CP connected to Global.",
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 61
+        },
+        "hiddenSeries": false,
+        "id": 58,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "kds_streams_active{instance=~\"$instance\",zone=\"Global\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Global - KDS active connections",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:534",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:535",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "Number of KDS messages exchanged between Global Control Plane and Zone Control Plane over KDS. Global sends to Zone policies and Ingress Dataplanes",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 4,
+            "y": 61
+        },
+        "hiddenSeries": false,
+        "id": 57,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:194",
+            "alias": "Configuration sent",
+            "color": "#5794F2"
+            },
+            {
+            "$$hashKey": "object:195",
+            "alias": "Configuration accepted",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:196",
+            "alias": "Configuration rejected",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:197",
+            "alias": "RPC Errors",
+            "color": "#C4162A"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(kds_responses_sent{instance=~\"$instance\",zone=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Configuration sent",
+            "refId": "A"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(kds_requests_received{confirmation=\"ACK\",instance=~\"$instance\",zone=\"Global\"}[1m]))",
+            "hide": true,
+            "interval": "",
+            "legendFormat": "Configuration accepted",
+            "refId": "B"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(kds_requests_received{confirmation=\"NACK\",instance=~\"$instance\",zone=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Configuration rejected",
+            "refId": "C"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "expr": "sum(rate(grpc_server_handled_total{grpc_service=\"kuma.mesh.v1alpha1.MultiplexService\",grpc_code!=\"OK\",instance=~\"$instance\",zone=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "RPC Errors",
+            "refId": "D"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "expr": "sum(rate(grpc_server_started_total{grpc_service=\"kuma.mesh.v1alpha1.MultiplexService\",instance=~\"$instance\",zone=\"Global\"}[1m]))",
+            "hide": true,
+            "interval": "",
+            "legendFormat": "Rate",
+            "refId": "E"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Global - KDS message exchange",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1007",
+            "format": "ops",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1008",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Number of KDS config generations per second. Config is sent only when it's different than previously generated. The value should be the number of connected control planes * KUMA_MULTIZONE_GLOBAL_KDS_REFRESH_INTERVAL",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 9,
+            "y": 61
+        },
+        "hiddenSeries": false,
+        "id": 59,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "alias": "Errors",
+            "color": "#F2495C"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(kds_generation_count{instance=~\"$instance\",zone=\"Global\"}[1m])) - sum(rate(kds_generation_errors{instance=~\"$instance\",zone=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Success",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(kds_generation_errors{instance=~\"$instance\",zone=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Errors",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Global - KDS config generations",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:850",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:851",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "How much it took to generate KDS configuration for a single zone control plane",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 14,
+            "y": 61
+        },
+        "hiddenSeries": false,
+        "id": 60,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "kds_generation{quantile=\"0.99\",instance=~\"$instance\",zone=\"Global\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Global - Latency of KDS config generation (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:988",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:989",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "How much it took to deliver Envoy configuration and receive ACK/NACK for a single dataplane",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 19,
+            "y": 61
+        },
+        "hiddenSeries": false,
+        "id": 83,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "kds_delivery{quantile=\"0.99\",instance=~\"$instance\",zone=\"Global\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Global - Latency of KDS config delivery (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:309",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:310",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Number of global CP connected to Zone.",
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 69
+        },
+        "hiddenSeries": false,
+        "id": 63,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "kds_streams_active{instance=~\"$instance\",zone!=\"Global\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Zone - KDS active connections",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:534",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:535",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "Number of KDS messages exchanged between Global Control Plane and Zone Control Plane over KDS. Zone sends to Global its Dataplanes and DataplaneInsights",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 4,
+            "y": 69
+        },
+        "hiddenSeries": false,
+        "id": 62,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:194",
+            "alias": "Configuration sent",
+            "color": "#5794F2"
+            },
+            {
+            "$$hashKey": "object:195",
+            "alias": "Configuration accepted",
+            "color": "#73BF69"
+            },
+            {
+            "$$hashKey": "object:196",
+            "alias": "Configuration rejected",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:197",
+            "alias": "RPC Errors",
+            "color": "#C4162A"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(kds_responses_sent{instance=~\"$instance\",zone!=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Configuration sent",
+            "refId": "A"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(kds_requests_received{confirmation=\"ACK\",instance=~\"$instance\",zone!=\"Global\"}[1m]))",
+            "hide": true,
+            "interval": "",
+            "legendFormat": "Configuration accepted",
+            "refId": "B"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "sum(rate(kds_requests_received{confirmation=\"NACK\",instance=~\"$instance\",zone!=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Configuration rejected",
+            "refId": "C"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "expr": "sum(rate(grpc_server_handled_total{grpc_service=\"kuma.mesh.v1alpha1.MultiplexService\",grpc_code!=\"OK\",instance=~\"$instance\",zone!=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "RPC Errors",
+            "refId": "D"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "expr": "sum(rate(grpc_server_started_total{grpc_service=\"kuma.mesh.v1alpha1.MultiplexService\",instance=~\"$instance\",zone!=\"Global\"}[1m]))",
+            "hide": true,
+            "interval": "",
+            "legendFormat": "Rate",
+            "refId": "E"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Zone - KDS message exchange",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1007",
+            "format": "ops",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1008",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Number of KDS config generations per second. Config is sent only when it's different than previously generated. The value should be the number of connected control planes * KUMA_MULTIZONE_ZONE_KDS_REFRESH_INTERVAL",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 9,
+            "y": 69
+        },
+        "hiddenSeries": false,
+        "id": 64,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "alias": "Errors",
+            "color": "#F2495C"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(kds_generation_count{instance=~\"$instance\",zone!=\"Global\"}[1m])) - sum(rate(kds_generation_errors{instance=~\"$instance\",zone!=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Success",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(kds_generation_errors{instance=~\"$instance\",zone!=\"Global\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Errors",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Zone - KDS config generations",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:850",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:851",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "How much it took to generate KDS configuration for a global control plane",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 14,
+            "y": 69
+        },
+        "hiddenSeries": false,
+        "id": 65,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "kds_generation{quantile=\"0.99\",instance=~\"$instance\",zone!=\"Global\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Zone - Latency of KDS config generation (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:988",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:989",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "How much it took to deliver Envoy configuration and receive ACK/NACK for a single dataplane",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 19,
+            "y": 69
+        },
+        "hiddenSeries": false,
+        "id": 84,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "exemplar": true,
+            "expr": "kds_delivery{quantile=\"0.99\",instance=~\"$instance\",zone!=\"Global\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Global - Latency of KDS config delivery (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:309",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:310",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 77
+        },
+        "id": 11,
+        "panels": [],
+        "title": "Store",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Latency of underlying storage (API Server on K8S, Postgres on Universal etc.)",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 7,
+            "x": 0,
+            "y": 78
+        },
+        "hiddenSeries": false,
+        "id": 12,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "histogram_quantile(0.99, sum by (operation, le) (rate(store_bucket{instance=~\"$instance\"}[1m])))",
+            "interval": "",
+            "legendFormat": "{{operation}}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency of Store operations (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:545",
+            "format": "s",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:546",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Cache protects underlying storage by sharing responses between many goroutines accessing the storage.\n\nhit - request was retrieved from the cache.\n\nhit-wait - request was retrieved from the cache after waiting for a concurrent request to fetch it from the database.\n\nmiss - request was fetched from the database\n\nRefer to https://kuma.io/docs/latest/documentation/fine-tuning/#snapshot-generation",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 5,
+            "x": 7,
+            "y": 78
+        },
+        "hiddenSeries": false,
+        "id": 14,
+        "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": true,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(store_cache{result=\"hit\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Hit",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(store_cache{result=\"hit-wait\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Hit Wait",
+            "refId": "C"
+            },
+            {
+            "expr": "sum(rate(store_cache{result=\"miss\",instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Miss",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Store cache performance",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:645",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:646",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Real requests executed on the underlying storage (Postgres/Kubernetes API Server)",
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 78
+        },
+        "hiddenSeries": false,
+        "id": 13,
+        "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum by (operation, resource_type) (rate(store_count{instance=~\"$instance\"}[1m]))",
+            "interval": "",
+            "legendFormat": "{{operation}} - {{resource_type}}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Store operations",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "decimals": 2,
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 87
+        },
+        "id": 35,
+        "panels": [],
+        "title": "Go Runtime",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 88
+        },
+        "hiddenSeries": false,
+        "id": 30,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "go_goroutines{instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Goroutines",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1463",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1464",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 88
+        },
+        "hiddenSeries": false,
+        "id": 31,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "go_threads{instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Threads",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1544",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1545",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 88
+        },
+        "hiddenSeries": false,
+        "id": 33,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "go_memstats_alloc_bytes{instance=~\"$instance\"}",
+            "interval": "",
+            "legendFormat": "{{ instance }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Memory allocated",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1693",
+            "format": "bytes",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1694",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 88
+        },
+        "hiddenSeries": false,
+        "id": 32,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "go_gc_duration_seconds{instance=~\"$instance\", quantile=\"0.75\"}",
+            "interval": "",
+            "legendFormat": "{{ instance}}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency of GC time (75th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:1774",
+            "format": "s",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:1775",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 34,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(cp_info, zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": false,
+            "name": "zone",
+            "options": [],
+            "query": {
+            "query": "label_values(cp_info, zone)",
+            "refId": "Prometheus-zone-Variable-Query"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(cp_info{zone=~\"$zone\"}, instance)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Instance",
+            "multi": false,
+            "name": "instance",
+            "options": [],
+            "query": {
+            "query": "label_values(cp_info{zone=~\"$zone\"}, instance)",
+            "refId": "Prometheus-instance-Variable-Query"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-15m",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "Kuma CP",
+    "uid": "z6C1v-NGk",
+    "version": 1,
+    "weekStart": ""
+    }

--- a/mesh/dashboards/kuma-dataplane.yaml
+++ b/mesh/dashboards/kuma-dataplane.yaml
@@ -1,0 +1,2609 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: kuma-dataplane
+  namespace: grafana
+spec:
+  datasources:
+  - datasourceName: prometheus-grafanadatasource
+    inputName: middleware.yaml
+  json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+            },
+            "type": "dashboard"
+        }
+        ]
+    },
+    "description": "Statistics of a single Dataplane in Kuma Service Mesh",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": 11775,
+    "graphTooltip": 0,
+    "id": 3,
+    "iteration": 1652204514580,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+        },
+        "id": 22,
+        "panels": [],
+        "title": "Dataplane",
+        "type": "row"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "displayName": "",
+            "mappings": [
+                {
+                "options": {
+                    "0": {
+                    "text": "OFF"
+                    },
+                    "1": {
+                    "text": "LIVE"
+                    }
+                },
+                "type": "value"
+                }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "red",
+                    "value": null
+                },
+                {
+                    "color": "green",
+                    "value": 1
+                }
+                ]
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 7,
+            "w": 5,
+            "x": 0,
+            "y": 1
+        },
+        "id": 16,
+        "interval": "",
+        "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+            "calcs": [
+                "last"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": false,
+            "text": {}
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "sum(envoy_server_live{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"} OR on() vector(0))",
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+            }
+        ],
+        "title": "Status",
+        "type": "gauge"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "s"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 5,
+            "y": 1
+        },
+        "id": 18,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "max"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto"
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "envoy_server_uptime{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}",
+            "refId": "A"
+            }
+        ],
+        "title": "Uptime",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "bytes"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 9,
+            "y": 1
+        },
+        "id": 25,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "mean"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto"
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "envoy_server_memory_heap_size{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}",
+            "refId": "A"
+            }
+        ],
+        "title": "Heap size",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "decimals": 2,
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "bytes"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 13,
+            "y": 1
+        },
+        "id": 26,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "mean"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto"
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "envoy_server_memory_allocated{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}",
+            "refId": "A"
+            }
+        ],
+        "title": "Memory allocated",
+        "type": "stat"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Note that if Control Plane does not sent FIN segment, Dataplanes can still think that connection is up waiting for new update even that Control Plane is down.",
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 7,
+            "w": 7,
+            "x": 17,
+            "y": 1
+        },
+        "hiddenSeries": false,
+        "id": 20,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "envoy_control_plane_connected_state{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}",
+            "legendFormat": "Connected",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Connection to the Control Plane",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": true,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 8
+        },
+        "id": 10,
+        "panels": [
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 2
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "envoy_cluster_upstream_cx_active{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Active Connections to this Dataplane",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 2
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 4,
+            "points": true,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{dataplane=\"$dataplane\",envoy_cluster_name=~\"localhost.*\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection time (P99)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "ms",
+                "label": "",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 2
+            },
+            "hiddenSeries": false,
+            "id": 32,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 4,
+            "points": true,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{dataplane=\"$dataplane\",envoy_cluster_name=~\"localhost.*\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection length (P99)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "ms",
+                "label": "",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 31,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_tx_bytes_total{dataplane=\"$dataplane\",envoy_cluster_name=~\"localhost.*\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Bytes received from requests",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "decbytes",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_rx_bytes_total{dataplane=\"$dataplane\",envoy_cluster_name=~\"localhost.*\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Bytes sent in responses",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "decbytes",
+                "label": "",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "description": "Data is only available if TrafficPermission policy is applied.",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "irate(envoy_rbac_allowed{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "Allowed - {{listener}}",
+                "refId": "A"
+                },
+                {
+                "expr": "irate(envoy_rbac_shadow_allowed{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "Shadow allowed - {{listener}}",
+                "refId": "D"
+                },
+                {
+                "expr": "irate(envoy_rbac_denied{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "Denied - {{listener}}",
+                "refId": "B"
+                },
+                {
+                "expr": "irate(envoy_rbac_shadow_denied{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "Shadow denied - {{listener}}",
+                "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Traffic permissions",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 30,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": true,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "hide": true,
+                "legendFormat": "connection destroyed by the client - {{envoy_cluster_name}}",
+                "refId": "A"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_connect_timeout{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "legendFormat": "connection timeout - {{envoy_cluster_name}}",
+                "refId": "B"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "hide": true,
+                "legendFormat": "connection destroyed by local Envoy - {{envoy_cluster_name}}",
+                "refId": "C"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_pending_failure_eject{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "legendFormat": "pending failure ejection - {{envoy_cluster_name}}",
+                "refId": "D"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_pending_overflow{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "legendFormat": "pending overflow - {{envoy_cluster_name}}",
+                "refId": "E"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_timeout{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "legendFormat": "request timeout - {{envoy_cluster_name}}",
+                "refId": "F"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_rx_reset{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "legendFormat": "response reset by the client - {{envoy_cluster_name}}",
+                "refId": "G"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_tx_reset{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost.*\"}[1m])",
+                "legendFormat": "request reset by local Envoy - {{envoy_cluster_name}}",
+                "refId": "H"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection/Requests errors",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            }
+        ],
+        "title": "Incoming traffic",
+        "type": "row"
+        },
+        {
+        "collapsed": true,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+        },
+        "id": 12,
+        "panels": [
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "envoy_cluster_upstream_cx_active{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}",
+                "interval": "",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Active Connections to other Dataplanes",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "$$hashKey": "object:203",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "$$hashKey": "object:204",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 33,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 4,
+            "points": true,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{dataplane=\"$dataplane\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection time (P99)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "ms",
+                "label": "",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 10
+            },
+            "hiddenSeries": false,
+            "id": 34,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 4,
+            "points": true,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{dataplane=\"$dataplane\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection length (P99)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "ms",
+                "label": "",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_rx_bytes_total{dataplane=\"$dataplane\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Bytes received from other Dataplanes",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "bytes",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 3,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_tx_bytes_total{dataplane=\"$dataplane\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Bytes sent to other Dataplanes",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "bytes",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "columns": [],
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "description": "Data is only available if TrafficPermission policy is applied.",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 18
+            },
+            "id": 24,
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "styles": [
+                {
+                "alias": "Time",
+                "align": "auto",
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "pattern": "Time",
+                "type": "date"
+                },
+                {
+                "alias": "",
+                "align": "auto",
+                "colors": [
+                    "rgba(245, 54, 54, 0.9)",
+                    "rgba(237, 129, 40, 0.89)",
+                    "rgba(50, 172, 45, 0.97)"
+                ],
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [
+                    ""
+                ],
+                "type": "number",
+                "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                "expr": "envoy_cluster_ssl_handshake{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"} > 0",
+                "format": "time_series",
+                "interval": "",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "title": "Secured destinations by mTLS",
+            "transform": "timeseries_aggregations",
+            "type": "table-old"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 26
+            },
+            "hiddenSeries": false,
+            "id": 29,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "hide": true,
+                "legendFormat": "destroyed by remote Envoy - {{envoy_cluster_name}}",
+                "refId": "A"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_connect_timeout{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "legendFormat": "connection timeout - {{envoy_cluster_name}}",
+                "refId": "B"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "hide": true,
+                "legendFormat": "destroyed by local Envoy - {{envoy_cluster_name}}",
+                "refId": "C"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_pending_failure_eject{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "legendFormat": "pending failure ejection - {{envoy_cluster_name}}",
+                "refId": "D"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_pending_overflow{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "legendFormat": "pending overflow - {{envoy_cluster_name}}",
+                "refId": "E"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_timeout{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "legendFormat": "request timeout - {{envoy_cluster_name}}",
+                "refId": "F"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_rx_reset{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "legendFormat": "request reset by other Envoy - {{envoy_cluster_name}}",
+                "refId": "G"
+                },
+                {
+                "expr": "irate(envoy_cluster_upstream_rq_tx_reset{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}[1m])",
+                "legendFormat": "response reset by local Envoy - {{envoy_cluster_name}}",
+                "refId": "H"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection/Requests errors",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            }
+        ],
+        "title": "Outgoing traffic",
+        "type": "row"
+        },
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 10
+        },
+        "id": 49,
+        "panels": [],
+        "title": "HTTP",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 51,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost_.*\",dataplane=\"$dataplane\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p99",
+            "refId": "B"
+            },
+            {
+            "expr": "sum(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost_.*\",dataplane=\"$dataplane\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p95",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost_.*\",dataplane=\"$dataplane\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p50",
+            "refId": "C"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:366",
+            "format": "ms",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:367",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 53,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost_.*\",dataplane=\"$dataplane\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Incoming",
+            "refId": "B"
+            },
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{kuma_io_zone=~\"$zone\",mesh=\"$mesh\",dataplane=\"$dataplane\",envoy_cluster_name!~\"localhost_.*\", envoy_cluster_name!=\"kuma_envoy_admin\", envoy_cluster_name!=\"kuma_metrics_hijacker\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Outgoing",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Traffic",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:366",
+            "format": "reqps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:367",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 55,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_external_upstream_rq_xx{kuma_io_zone=~\"$zone\",mesh=\"$mesh\",dataplane=\"$dataplane\", envoy_cluster_name=~\"localhost_.*\"}[1m])) by (envoy_response_code_class)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Incoming {{envoy_response_code_class}}xx",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(envoy_cluster_external_upstream_rq_xx{kuma_io_zone=~\"$zone\",mesh=\"$mesh\",dataplane=\"$dataplane\", envoy_cluster_name!~\"localhost_.*\", envoy_cluster_name!=\"kuma_envoy_admin\", envoy_cluster_name!=\"kuma_metrics_hijacker\"}[1m])) by (envoy_response_code_class)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Outgoing {{envoy_response_code_class}}xx",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Status codes",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:242",
+            "format": "reqps",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:243",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": true,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+        },
+        "id": 36,
+        "panels": [
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "description": "Data is only available if HealthCheck policy is applied.",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 38,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "envoy_cluster_health_check_healthy{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Active Health Checks - healthy service instances",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "$$hashKey": "object:353",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "$$hashKey": "object:354",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "description": "Data is only available if HealthCheck policy is applied.",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 4
+            },
+            "hiddenSeries": false,
+            "id": 39,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "envoy_cluster_membership_total{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"} - envoy_cluster_health_check_healthy{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}",
+                "legendFormat": "{{envoy_cluster_name}}",
+                "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Active Health Checks - failing service instances",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "$$hashKey": "object:384",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "$$hashKey": "object:385",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            }
+        ],
+        "title": "Health Checks",
+        "type": "row"
+        },
+        {
+        "collapsed": true,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 21
+        },
+        "id": 45,
+        "panels": [
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "description": "Total times that the cluster’s connection circuit breaker overflowed",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 43,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "interval": "",
+                "legendFormat": "Connection overflow",
+                "refId": "A"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Pending request overflow",
+                "refId": "B"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Retry overflow",
+                "refId": "C"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Thresholds Overflow",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "$$hashKey": "object:72",
+                "format": "ops",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "$$hashKey": "object:73",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "description": "Data is only available if HealthCheck policy is applied. Note that passive health checks are executed on healthy instances marked by active health checks.",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 47,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{dataplane=\"$dataplane\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
+                "interval": "",
+                "legendFormat": "Healthy destinations",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Outlier detection",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "$$hashKey": "object:312",
+                "format": "percentunit",
+                "logBase": 1,
+                "max": "1",
+                "min": "0",
+                "show": true
+                },
+                {
+                "$$hashKey": "object:313",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            }
+        ],
+        "title": "Circuit Breakers",
+        "type": "row"
+        }
+    ],
+    "schemaVersion": 34,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": false,
+            "text": "default",
+            "value": "default"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live, mesh)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Mesh",
+            "multi": false,
+            "name": "mesh",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live, mesh)",
+            "refId": "Prometheus-mesh-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allFormat": "wildcard",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": true,
+            "name": "zone",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "refId": "Prometheus-zone-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "current": {
+            "selected": false,
+            "text": "kuma-demo-backend-v0-56db47c579-hhjn6.kuma-demo",
+            "value": "kuma-demo-backend-v0-56db47c579-hhjn6.kuma-demo"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, dataplane)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Dataplane",
+            "multi": false,
+            "name": "dataplane",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, dataplane)",
+            "refId": "Prometheus-dataplane-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-15m",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "Kuma Dataplane",
+    "uid": "-SZYLFyWz",
+    "version": 1,
+    "weekStart": ""
+    }

--- a/mesh/dashboards/kuma-mesh.yaml
+++ b/mesh/dashboards/kuma-mesh.yaml
@@ -1,0 +1,1184 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: kuma-mesh
+  namespace: grafana
+spec:
+  datasources:
+  - datasourceName: prometheus-grafanadatasource
+    inputName: middleware.yaml
+  json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+            },
+            "type": "dashboard"
+        }
+        ]
+    },
+    "description": "Statistics of the single Mesh in Kuma Service Mesh",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": 11774,
+    "graphTooltip": 0,
+    "id": 4,
+    "iteration": 1652204444590,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+        },
+        "id": 30,
+        "panels": [],
+        "title": "Service Map",
+        "type": "row"
+        },
+        {
+        "datasource": {
+            "type": "kumahq-kuma-datasource",
+            "uid": "kuma"
+        },
+        "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 1
+        },
+        "id": 32,
+        "interval": "1m",
+        "targets": [
+            {
+            "hide": false,
+            "mesh": "$mesh",
+            "queryType": "mesh-graph",
+            "refId": "A"
+            }
+        ],
+        "title": "Service Map",
+        "type": "nodeGraph"
+        },
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 15
+        },
+        "id": 23,
+        "panels": [],
+        "title": "HTTP",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 16
+        },
+        "hiddenSeries": false,
+        "id": 25,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",envoy_cluster_name=~\"localhost_.*\"}[1m]))) by (kuma_io_service)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{ kuma_io_service }}",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency (99th percentile)",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:366",
+            "format": "ms",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:367",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 16
+        },
+        "hiddenSeries": false,
+        "id": 26,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",envoy_cluster_name=~\"localhost_.*\"}[1m])) by (kuma_io_service)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{ kuma_io_service }}",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Traffic",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:366",
+            "format": "reqps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "$$hashKey": "object:367",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 16
+        },
+        "hiddenSeries": false,
+        "id": 28,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null as zero",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_external_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",envoy_cluster_name=~\"localhost_.*\", envoy_response_code_class=~\"4|5\"}[1m])) by (kuma_io_service,envoy_response_code_class)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{ kuma_io_service}} {{ envoy_response_code_class }}xx",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Error Status Codes",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:242",
+            "format": "reqps",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:243",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 25
+        },
+        "id": 16,
+        "panels": [],
+        "title": "Health Checks",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Data is only available if HealthCheck policy is applied.",
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 26
+        },
+        "hiddenSeries": false,
+        "id": 9,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "((sum(rate(envoy_cluster_health_check_success{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m])) / sum(rate(envoy_cluster_health_check_attempt{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))))",
+            "legendFormat": "Success rate",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Active Health Checks",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "percentunit",
+            "logBase": 1,
+            "max": "1",
+            "min": "0",
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 33
+        },
+        "id": 19,
+        "panels": [],
+        "title": "Circuit Breakers",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "Total times that the cluster’s connection circuit breaker overflowed",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+        },
+        "hiddenSeries": false,
+        "id": 21,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Connection overflow",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Pending request overflow",
+            "refId": "B"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Retry overflow",
+            "refId": "C"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Thresholds Overflow",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:72",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:73",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Data is only available if HealthCheck policy is applied. Note that passive health checks are executed on healthy instances marked by active health checks.",
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+        },
+        "hiddenSeries": false,
+        "id": 17,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}) / sum(envoy_cluster_membership_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"})",
+            "interval": "",
+            "legendFormat": "Healthy destinations",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Outlier detection",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "percentunit",
+            "logBase": 1,
+            "max": "1",
+            "min": "0",
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 42
+        },
+        "id": 12,
+        "panels": [],
+        "title": "Data Plane Proxies",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 43
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:224",
+            "alias": "Off",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:225",
+            "alias": "Live",
+            "color": "#73BF69"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "count(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}) - sum(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"})",
+            "hide": false,
+            "legendFormat": "Off",
+            "refId": "B"
+            },
+            {
+            "expr": "sum(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"})",
+            "hide": false,
+            "legendFormat": "Live",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Dataplanes",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:238",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:239",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Note that if Control Plane does not sent FIN segment, Dataplanes can still think that connection is up waiting for new update even that Control Plane is down.",
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 43
+        },
+        "hiddenSeries": false,
+        "id": 3,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+            {
+            "$$hashKey": "object:293",
+            "alias": "Disconnected",
+            "color": "#F2495C"
+            },
+            {
+            "$$hashKey": "object:294",
+            "alias": "Connected",
+            "color": "#73BF69"
+            }
+        ],
+        "spaceLength": 10,
+        "stack": true,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "count(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}) - sum(envoy_control_plane_connected_state{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"})",
+            "legendFormat": "Disconnected",
+            "refId": "B"
+            },
+            {
+            "expr": "sum(envoy_control_plane_connected_state{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"})",
+            "legendFormat": "Connected",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Dataplanes connected to the Control Plane",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:307",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:308",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+        },
+        "hiddenSeries": false,
+        "id": 5,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Sent",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Received",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Bytes flowing through Envoy",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "decbytes",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+        },
+        "hiddenSeries": false,
+        "id": 7,
+        "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "hide": true,
+            "legendFormat": "Connection destroyed by the client",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Connection timeout",
+            "refId": "B"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "hide": true,
+            "legendFormat": "Connection destroyed by local Envoy",
+            "refId": "C"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Pending failure ejection",
+            "refId": "D"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Pending overflow",
+            "refId": "E"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Request timeout",
+            "refId": "F"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Response reset",
+            "refId": "G"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}[1m]))",
+            "legendFormat": "Request reset",
+            "refId": "H"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Connection/Requests errors",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 34,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": false,
+            "text": "default",
+            "value": "default"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live, mesh)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Mesh",
+            "multi": false,
+            "name": "mesh",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live, mesh)",
+            "refId": "Prometheus-mesh-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allFormat": "wildcard",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": true,
+            "name": "zone",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "refId": "Prometheus-zone-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-15m",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "Kuma Mesh",
+    "uid": "GW0DqjsWz",
+    "version": 1,
+    "weekStart": ""
+    }

--- a/mesh/dashboards/kuma-service-to-service.yaml
+++ b/mesh/dashboards/kuma-service-to-service.yaml
@@ -1,0 +1,1290 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: kuma-service-to-service
+  namespace: grafana
+spec:
+  datasources:
+  - datasourceName: prometheus-grafanadatasource
+    inputName: middleware.yaml
+  json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+            },
+            "type": "dashboard"
+        }
+        ]
+    },
+    "description": "Statistics of the traffic between services in Kuma Service Mesh",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": 11776,
+    "graphTooltip": 0,
+    "id": 5,
+    "iteration": 1652205290138,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+        "collapsed": true,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+        },
+        "id": 10,
+        "panels": [
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 1
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Bytes sent",
+                "refId": "A"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Bytes received",
+                "refId": "B"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Traffic from source service perspective",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "decbytes",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 1
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": false,
+                "hideZero": false,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "hide": true,
+                "legendFormat": "Connection destroyed by the client",
+                "refId": "A"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_cx_connect_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Connection timeout",
+                "refId": "B"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "hide": true,
+                "legendFormat": "Connection destroyed by local Envoy",
+                "refId": "C"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_rq_pending_failure_eject{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Pending failure ejection",
+                "refId": "D"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Pending overflow",
+                "refId": "E"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_rq_timeout{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Request timeout",
+                "refId": "F"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_rq_rx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Response reset",
+                "refId": "G"
+                },
+                {
+                "expr": "sum(irate(envoy_cluster_upstream_rq_tx_reset{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+                "legendFormat": "Request reset",
+                "refId": "H"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection/Requests errors from source service perspective",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "interval": "",
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
+                "legendFormat": "Connections",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Active Connections between services",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 4,
+            "points": true,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_connect_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
+                "legendFormat": "Time",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection time (P99)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "ms",
+                "label": "",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 4,
+            "points": true,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "max(histogram_quantile(0.99, irate(envoy_cluster_upstream_cx_length_ms_bucket{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m])))",
+                "legendFormat": "Time",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Connection length (P99)",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "ms",
+                "label": "",
+                "logBase": 1,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            }
+        ],
+        "title": "Traffic",
+        "type": "row"
+        },
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 1
+        },
+        "id": 25,
+        "panels": [],
+        "title": "HTTP",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 2
+        },
+        "hiddenSeries": false,
+        "id": 27,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null as zero",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p99",
+            "refId": "A"
+            },
+            {
+            "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p95",
+            "refId": "C"
+            },
+            {
+            "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_service=\"$source_service\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=\"$destination_cluster\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p50",
+            "refId": "D"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:631",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:632",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 2
+        },
+        "hiddenSeries": false,
+        "id": 29,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_service=\"$source_service\", envoy_cluster_name=\"$destination_cluster\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Requests",
+            "refId": "C"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Traffic",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:429",
+            "format": "reqps",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:430",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 2
+        },
+        "hiddenSeries": false,
+        "id": 31,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_external_upstream_rq_xx{mesh=\"$mesh\",kuma_io_service=\"$source_service\", envoy_cluster_name=\"$destination_cluster\"}[1m])) by (envoy_response_code_class)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{envoy_response_code_class}}xx",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Status codes",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:242",
+            "format": "reqps",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:243",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": true,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 11
+        },
+        "id": 18,
+        "panels": [
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+            },
+            "description": "Data is only available if HealthCheck policy is applied.",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {},
+                "links": []
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.4.3",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(envoy_cluster_health_check_healthy{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
+                "legendFormat": "Healthy destinations",
+                "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeRegions": [],
+            "title": "Active Health Checks",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "mode": "time",
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "$$hashKey": "object:347",
+                "format": "percentunit",
+                "logBase": 1,
+                "max": "1",
+                "min": "0",
+                "show": true
+                },
+                {
+                "$$hashKey": "object:348",
+                "format": "short",
+                "logBase": 1,
+                "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false
+            }
+            }
+        ],
+        "title": "Health Checks",
+        "type": "row"
+        },
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 12
+        },
+        "id": 23,
+        "panels": [],
+        "title": "Circuit Breakers",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "Total times that the cluster’s connection circuit breaker overflowed",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+        },
+        "hiddenSeries": false,
+        "id": 21,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_cx_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+            "interval": "",
+            "legendFormat": "Connection overflow",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_pending_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Pending request overflow",
+            "refId": "B"
+            },
+            {
+            "expr": "sum(irate(envoy_cluster_upstream_rq_retry_overflow{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Retry overflow",
+            "refId": "C"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Thresholds Overflow",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:72",
+            "format": "ops",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:73",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+        },
+        "description": "Data is only available if CircuitBreaker policy is applied",
+        "fieldConfig": {
+            "defaults": {
+            "links": []
+            },
+            "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+        },
+        "hiddenSeries": false,
+        "id": 19,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "1 - sum(envoy_cluster_outlier_detection_ejections_active{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"}) / sum(envoy_cluster_membership_total{kuma_io_service=\"$source_service\",envoy_cluster_name=\"$destination_cluster\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\"})",
+            "interval": "",
+            "legendFormat": "Healthy destinations",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Outlier detection",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:402",
+            "format": "percentunit",
+            "logBase": 1,
+            "max": "1",
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:403",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 34,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": false,
+            "text": "default",
+            "value": "default"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live, mesh)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Mesh",
+            "multi": false,
+            "name": "mesh",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live, mesh)",
+            "refId": "Prometheus-mesh-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allFormat": "wildcard",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": true,
+            "name": "zone",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "refId": "Prometheus-zone-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "current": {
+            "selected": false,
+            "text": "backend_kuma-demo_svc_3001",
+            "value": "backend_kuma-demo_svc_3001"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Source service",
+            "multi": false,
+            "name": "source_service",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_service)",
+            "refId": "Prometheus-source_service-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "current": {
+            "selected": false,
+            "text": "frontend_kuma-demo_svc_8080",
+            "value": "frontend_kuma-demo_svc_8080"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}, envoy_cluster_name)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Destination service",
+            "multi": false,
+            "name": "destination_cluster",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_cluster_upstream_cx_active{kuma_io_service=\"$source_service\",envoy_cluster_name!~\"(localhost.*)|ads_cluster|kuma_envoy_admin|access_log_sink\"}, envoy_cluster_name)",
+            "refId": "Prometheus-destination_cluster-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "Kuma Service to Service",
+    "uid": "QdCgOqyWz",
+    "version": 1,
+    "weekStart": ""
+    }

--- a/mesh/dashboards/kuma-service.yaml
+++ b/mesh/dashboards/kuma-service.yaml
@@ -1,0 +1,949 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: kuma-service
+  namespace: grafana
+spec:
+  datasources:
+  - datasourceName: prometheus-grafanadatasource
+    inputName: middleware.yaml
+  json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+            },
+            "type": "dashboard"
+        }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 6,
+    "iteration": 1652204615996,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+            },
+            "mappings": [],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": []
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 0
+        },
+        "id": 12,
+        "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+            "calcs": [
+                "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "count(envoy_server_live{kuma_io_services=~\".*$service.*\"})",
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+            }
+        ],
+        "title": "Dataplanes",
+        "transformations": [],
+        "type": "stat"
+        },
+        {
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "custom": {
+                "displayMode": "auto",
+                "filterable": false
+            },
+            "mappings": [],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": []
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 0
+        },
+        "id": 23,
+        "options": {
+            "footer": {
+            "fields": "",
+            "reducer": [
+                "sum"
+            ],
+            "show": false
+            },
+            "showHeader": false
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "sum(envoy_server_live{kuma_io_services=~\".*$service.*\"}) by (dataplane)",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+            }
+        ],
+        "title": "Dataplanes",
+        "transformations": [
+            {
+            "id": "labelsToFields",
+            "options": {}
+            },
+            {
+            "id": "merge",
+            "options": {}
+            },
+            {
+            "id": "organize",
+            "options": {
+                "excludeByName": {
+                "Time": true,
+                "Value": true,
+                "app": true,
+                "apps": true,
+                "env": true,
+                "envs": true,
+                "instance": true,
+                "job": true,
+                "k8s_kuma_io_name": true,
+                "k8s_kuma_io_namespace": true,
+                "kuma_io_protocol": true,
+                "kuma_io_protocols": true,
+                "kuma_io_service": true,
+                "kuma_io_services": true,
+                "mesh": true,
+                "namespace": true,
+                "pod": true,
+                "pod_template_hash": true,
+                "pod_template_hashs": true,
+                "version": true,
+                "versions": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                "dataplane": "Dataplanes",
+                "env": ""
+                }
+            }
+            },
+            {
+            "id": "merge",
+            "options": {}
+            }
+        ],
+        "type": "table"
+        },
+        {
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "displayName": "Incoming",
+            "mappings": [],
+            "noValue": "0",
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "reqps"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 4,
+            "w": 8,
+            "x": 16,
+            "y": 0
+        },
+        "id": 15,
+        "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+            "calcs": [
+                "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "text": {},
+            "textMode": "value_and_name"
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_services=~\".*$service.*\",envoy_cluster_name=~\"localhost_.*\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "C"
+            }
+        ],
+        "type": "stat"
+        },
+        {
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "displayName": "Outgoing",
+            "mappings": [],
+            "noValue": "0",
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "reqps"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 4,
+            "w": 8,
+            "x": 16,
+            "y": 4
+        },
+        "id": 22,
+        "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+            "calcs": [
+                "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "text": {},
+            "textMode": "value_and_name"
+        },
+        "pluginVersion": "8.3.3",
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_services=~\".*$service.*\",envoy_cluster_name!~\"localhost_.*\",envoy_cluster_name!=\"kuma_envoy_admin\",envoy_cluster_name!=\"kuma_metrics_hijacker\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "C"
+            }
+        ],
+        "type": "stat"
+        },
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 8
+        },
+        "id": 14,
+        "panels": [],
+        "title": "HTTP",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 9
+        },
+        "hiddenSeries": false,
+        "id": 4,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "max(histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_services=~\".*$service.*\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost_.*\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p99",
+            "refId": "A"
+            },
+            {
+            "expr": "max(histogram_quantile(0.95, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_services=~\".*$service.*\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost_.*\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p95",
+            "refId": "C"
+            },
+            {
+            "expr": "max(histogram_quantile(0.50, rate(envoy_cluster_upstream_rq_time_bucket{kuma_io_services=~\".*$service.*\",kuma_io_zone=~\"$zone\",mesh=\"$mesh\",envoy_cluster_name=~\"localhost_.*\"}[1m])))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "p50",
+            "refId": "D"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Latency",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:631",
+            "format": "ms",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:632",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 9
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_services=~\".*$service.*\", envoy_cluster_name=~\"localhost_.*\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Incoming",
+            "refId": "C"
+            },
+            {
+            "expr": "sum(rate(envoy_cluster_upstream_rq_total{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_services=~\".*$service.*\", envoy_cluster_name!~\"localhost_.*\", envoy_cluster_name!=\"kuma_envoy_admin\",envoy_cluster_name!=\"kuma_metrics_hijacker\"}[1m]))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Outgoing",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Traffic",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:429",
+            "format": "reqps",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:430",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 9
+        },
+        "hiddenSeries": false,
+        "id": 10,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(envoy_cluster_external_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_services=~\".*$service.*\", envoy_cluster_name=~\"localhost_.*\"}[1m])) by (envoy_response_code_class)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Incoming {{envoy_response_code_class}}xx",
+            "refId": "A"
+            },
+            {
+            "expr": "sum(rate(envoy_cluster_external_upstream_rq_xx{mesh=\"$mesh\",kuma_io_zone=~\"$zone\",kuma_io_services=~\".*$service.*\", envoy_cluster_name!~\"localhost_.*\", envoy_cluster_name!=\"kuma_envoy_admin\", envoy_cluster_name!=\"kuma_metrics_hijacker\"}[1m])) by (envoy_response_code_class)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Outgoing {{envoy_response_code_class}}xx",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Status codes",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:242",
+            "format": "reqps",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:243",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "collapsed": false,
+        "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+        },
+        "id": 17,
+        "panels": [],
+        "title": "Kubernetes",
+        "type": "row"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 19
+        },
+        "hiddenSeries": false,
+        "id": 8,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "max(sum(rate(container_cpu_usage_seconds_total[1m])) by (namespace, pod) * on (namespace, pod) group_right(kuma_io_service) envoy_server_live{kuma_io_services=~\".*$service.*\"}) by (dataplane) /\nmax(sum(kube_pod_container_resource_limits_cpu_cores) by (namespace, pod) * on (namespace, pod) group_right(kuma_io_service) envoy_server_live{kuma_io_services=~\".*$service.*\"}) by (dataplane)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{ dataplane }}",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "CPU",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:854",
+            "format": "percentunit",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:855",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 19
+        },
+        "hiddenSeries": false,
+        "id": 21,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "max(sum(container_memory_working_set_bytes{image!=\"\"}) by (namespace, pod) * on (namespace, pod) group_right(kuma_io_service) envoy_server_live{kuma_io_services=~\".*$service.*\"}) by (dataplane)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{ dataplane }}",
+            "refId": "B"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Memory Utilization",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:44",
+            "format": "short",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:45",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 19
+        },
+        "hiddenSeries": false,
+        "id": 7,
+        "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.3.3",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "max(sum(container_memory_working_set_bytes) by (namespace, pod) * on (namespace, pod) group_right(kuma_io_service) envoy_server_live{kuma_io_services=~\".*$service.*\"}) by (dataplane) / max(sum(kube_pod_container_resource_limits_memory_bytes) by (namespace, pod) * on (namespace, pod) group_right(kuma_io_service) envoy_server_live{kuma_io_services=~\".*$service.*\"}) by (dataplane)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{ dataplane }}",
+            "refId": "A"
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Memory Saturation",
+        "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "$$hashKey": "object:854",
+            "format": "percentunit",
+            "logBase": 1,
+            "min": "0",
+            "show": true
+            },
+            {
+            "$$hashKey": "object:855",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 34,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": false,
+            "text": "default",
+            "value": "default"
+            },
+            "definition": "label_values(envoy_server_live, mesh)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Mesh",
+            "multi": false,
+            "name": "mesh",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live, mesh)",
+            "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allFormat": "wildcard",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Zone",
+            "multi": true,
+            "name": "zone",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\"}, kuma_io_zone)",
+            "refId": "Prometheus-zone-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "current": {
+            "selected": false,
+            "text": "backend_kuma-demo_svc_3001",
+            "value": "backend_kuma-demo_svc_3001"
+            },
+            "definition": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Service",
+            "multi": false,
+            "name": "service",
+            "options": [],
+            "query": {
+            "query": "label_values(envoy_server_live{mesh=\"$mesh\",kuma_io_zone=~\"$zone\"}, kuma_io_service)",
+            "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-15m",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Kuma Service",
+    "uid": "FkJ7AxwMz",
+    "version": 1,
+    "weekStart": ""
+    }


### PR DESCRIPTION
This PR includes Grafana Dashboards, and a `kong-mesh-federation.md` doc.

The markdown goes into:
- ServiceMonitor and ClusterRoles to Federate Kong Prometheus to OpenShift Prometheus with deduplicated data
- PrometheusRules to trigger alerts
- Installation of the Grafana Operator and creation of dashboards (Kong's Dashboards) 